### PR TITLE
Avoid duplicate key warnings on key

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -421,8 +421,8 @@ export default class AgendaView extends Component {
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
           {this.props.showWeekNumbers && <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>}
-          {weekDaysNames.map((day) => (
-            <Text allowFontScaling={false} key={day} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
+          {weekDaysNames.map((day, index) => (
+            <Text allowFontScaling={false} key={day+index} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
           ))}
         </Animated.View>
         <Animated.ScrollView


### PR DESCRIPTION
weekDaysNames have an array of days in abbreviated letters, e.g. "S" for Sunday, and "S" for Saturday. React Native does not like that the key element have duplicates of the same key. Causes the "encountered two children with the same key" warning. Adding the index of the weekDaysNames array avoids duplicates, removing the warning.